### PR TITLE
Use `destroy` instead of `end`

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(opts, cb) {
   function attemptConnection() {
     console.log(new Date().toISOString()+' Waiting to connect to '+service+'...');
     var client = net.connect(opts, function() {
-      client.end();
+      client.destroy();
       console.log(service+' is available.');
       cb();
     }).on('error', function(err) {


### PR DESCRIPTION
Getting this error on master. Replacing `end` with `destroy` fixes the issue.

```
TAP version 13
# fires cb when connected
2016-03-10T15:53:58.195Z Waiting to connect to service...
service is available.
ok 1 (unnamed assert)
# fires cb with err when timed out
2016-03-10T15:53:58.202Z Waiting to connect to service...
2016-03-10T15:53:58.248Z Waiting to connect to service...
2016-03-10T15:53:58.293Z Waiting to connect to service...
2016-03-10T15:53:58.337Z Waiting to connect to service...
ok 2 (unnamed assert)
# attempts connection at set interval
ok 3 should be equal
# uses service name in logs
ok 4 (unnamed assert)
2016-03-10T15:53:59.202Z Waiting to connect to service...
not ok 5 (unnamed assert)
  ---
    operator: notOk
    expected: |-
      false
    actual: |-
      'service could not be reached in 1000ms. Error: connect ECONNREFUSED 127.0.0.1:9999'
    at: Socket.<anonymous> (/node-when-cnct-ready/index.js:26:9)
  ...
not ok 6 plan != count
  ---
    operator: fail
    expected: 1
    actual:   2
    at: Socket.<anonymous> (/node-when-cnct-ready/index.js:26:9)
  ...

1..6
# tests 6
# pass  4
# fail  2
```
